### PR TITLE
Add transactions to LeaseQueueItem

### DIFF
--- a/Data/MySQL/stored-procedures/LeaseQueueItem.sql
+++ b/Data/MySQL/stored-procedures/LeaseQueueItem.sql
@@ -5,22 +5,31 @@ CREATE PROCEDURE `LeaseQueueItem`(
 	IN _LockExpiration DATETIME
 )
 BEGIN
+	START TRANSACTION;
+
 	SET @HolderID = UUID();
+	SET @ID = (SELECT `ID`
+		FROM `queue`.`queue-items`
+		WHERE (`QueueID` = _QueueID)
+		AND (`LockExpiration` < UTC_Timestamp())
+		ORDER BY `ID` ASC
+		LIMIT 1
+		FOR UPDATE);
 
 	UPDATE `queue`.`queue-items`
 	SET
 		`HolderID` = @HolderID,
 		`LockExpiration` = _LockExpiration,
 		`Updated` = UTC_Timestamp()
-	WHERE (`QueueID` = _QueueID)
-	AND (`LockExpiration` < UTC_Timestamp())
-	ORDER BY `ID` ASC
+	WHERE (`ID` = @ID)
 	LIMIT 1;
 
 	SELECT *
 		FROM `queue`.`queue-items`
-		WHERE `HolderID` = @HolderID
+		WHERE `ID` = @ID
 		LIMIT 1;
+
+	COMMIT;
 END$$
 
 DELIMITER ;


### PR DESCRIPTION
This _should_ prevent multiple threads executing `LeaseQueueItem` from leasing the same row.
Sources:
- https://stackoverflow.com/a/7523328/1663648
- https://stackoverflow.com/a/45356982/1663648

```sql
SELECT `ID` INTO @ID
```
I ended up using `SET @ID = (SELECT ...` because `SELECT INTO @ID` would select a "closest match" `@ID`, even if the `WHERE` clause did not fully match.